### PR TITLE
Fix ADC reference in temp calculation

### DIFF
--- a/fire_gas_D.ino
+++ b/fire_gas_D.ino
@@ -14,6 +14,7 @@ const int ledRedPin = 2;
 // the limits to made beeb noise 
 const float tempThreshold = 35.0;
 const float gasVoltThreshold = 1.5;
+const float adcRefVoltage = 5.0;
 
 // for o/p pins in Arduino 
 void setup() {
@@ -32,7 +33,7 @@ void loop() {
   int tempRaw = analogRead(lm35Pin);
   int gasRaw  = analogRead(mq6Pin);
 
-  float temperature = (tempRaw / 1023.0) * 3.3 * 100.0;  // Equation of temp. read 
+  float temperature = (tempRaw / 1023.0) * adcRefVoltage * 100.0;  // Equation of temp. read
   float gasVoltage  = (gasRaw / 1023.0) * 5.0;           // Equation of gas read
  //boolean
   bool danger = (temperature > tempThreshold || gasVoltage > gasVoltThreshold);


### PR DESCRIPTION
## Summary
- define `adcRefVoltage` for the ADC reference voltage
- use this constant when computing the temperature

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509346c3348327838f42ced0a8e9d0