### PR TITLE
Fix green LED behavior

### DIFF
--- a/fire_gas_D.ino
+++ b/fire_gas_D.ino
@@ -38,6 +38,7 @@ void loop() {
   bool danger = (temperature > tempThreshold || gasVoltage > gasVoltThreshold);
   digitalWrite(buzzerPin, danger);
   digitalWrite(ledRedPin, danger);
+  digitalWrite(ledGreenPin, !danger);
 
   u8g2.clearBuffer();
   u8g2.setFont(u8g2_font_ncenB08_tr);


### PR DESCRIPTION
## Summary
- ensure safe mode only lights the green LED by turning it off when detecting danger

## Testing
- `tail -n 2 -v fire_gas_D.ino`

------
https://chatgpt.com/codex/tasks/task_e_68508f0747288327bfbfa5e7cff836cb